### PR TITLE
fix: fix var name

### DIFF
--- a/SM/src/sm/sm_nine2one.js
+++ b/SM/src/sm/sm_nine2one.js
@@ -1,30 +1,30 @@
-const SlotSize = 155286;
-
+const SLOT_SIZE = 155286;
 
 module.exports.buildConstants = async function (pols) {
-    const N = pols.FieldLatch.length;
+    const fieldLatchLength = pols.FieldLatch.length;
+    const n = fieldLatchLength;
 
-    const nSlots = Math.floor((N-1)/SlotSize);
+    const nSlots = Math.floor((n - 1) / SLOT_SIZE);
 
-    for (i=0; i<N; i++) {
+    for (let i = 0; i < n; i++) {
         let slot = -1;
         let iRel;
-        if (i>0) {
-            slot = Math.floor( (i - 1) / SlotSize );
+        if (i > 0) {
+            slot = Math.floor((i - 1) / SLOT_SIZE);
             if (slot < nSlots) {
-                iRel = (i-1) % SlotSize;
+                iRel = (i - 1) % SLOT_SIZE;
             } else {
                 slot = -1;
             }
         }
         if (slot >= 0) {
-            if ( ((iRel%44) == 0) && (iRel<=44*3200) && (iRel>0) ) {
+            if (((iRel % 44) == 0) && (iRel <= 44 * 3200) && (iRel > 0)) {
                 pols.FieldLatch[i] = 1n;
             } else {
                 pols.FieldLatch[i] = 0n;
             }
-            if (iRel < 44*3200) {
-                pols.Factor[i] = 1n << BigInt(iRel%44);
+            if (iRel < 44 * 3200) {
+                pols.Factor[i] = 1n << BigInt(iRel % 44);
             } else {
                 pols.Factor[i] = 0n;
             }
@@ -43,11 +43,11 @@ module.exports.execute = async function (pols, input) {
         KeccakF: []
     };
 
-    const N = pols.bit.length;
+    const bitLength = pols.bit.length;
 
-    const nSlots = Math.floor((N-1)/SlotSize);
+    const nSlots = Math.floor((bitLength - 1) / SLOT_SIZE);
 
-    let p=0;
+    let p = 0;
 
     pols.bit[p] = 0n;
     pols.field44[p] = 0n;
@@ -56,24 +56,24 @@ module.exports.execute = async function (pols, input) {
     let accField = 0n;
 
 
-    for (let i=0; i<nSlots; i++) {
+    for (let i = 0; i < nSlots; i++) {
         const keccakFSlot = [];
-        for (j=0; j<1600; j++) {
-            for (k=0; k<44; k++) {
-                pols.bit[p] = getBit(i*44+k, false, j);
+        for (let j = 0; j < 1600; j++) {
+            for (let k = 0; k < 44; k++) {
+                pols.bit[p] = getBit(i * 44 + k, false, j);
                 pols.field44[p] = accField;
-                accField = k==0 ? pols.bit[p] :
-                    accField +  (pols.bit[p] << BigInt(k));
+                accField = k == 0 ? pols.bit[p] :
+                    accField + (pols.bit[p] << BigInt(k));
                 p += 1;
             }
             keccakFSlot.push(accField);
         }
-        for (j=0; j<1600; j++) {
-            for (k=0; k<44; k++) {
-                pols.bit[p] = getBit(i*44+k, true, j);
+        for (let j = 0; j < 1600; j++) {
+            for (let k = 0; k < 44; k++) {
+                pols.bit[p] = getBit(i * 44 + k, true, j);
                 pols.field44[p] = accField;
-                accField = k==0 ? pols.bit[p] :
-                    accField +  (pols.bit[p] << BigInt(k));
+                accField = k == 0 ? pols.bit[p] :
+                    accField + (pols.bit[p] << BigInt(k));
                 p += 1;
             }
         }
@@ -83,7 +83,7 @@ module.exports.execute = async function (pols, input) {
         accField = 0n;
         p += 1;
 
-        for (j=3200*44+1; j<SlotSize; j++) {
+        for (let j = 3200 * 44 + 1; j < SLOT_SIZE; j++) {
             pols.bit[p] = 0n;
             pols.field44[p] = 0n;
             p += 1;
@@ -92,7 +92,7 @@ module.exports.execute = async function (pols, input) {
         required.KeccakF.push(keccakFSlot);
     }
 
-    while (p<N) {
+    while (p < bitLength) {
         pols.bit[p] = 0n;
         pols.field44[p] = 0n;
         p += 1;
@@ -102,20 +102,20 @@ module.exports.execute = async function (pols, input) {
 
 
     function getBit(block, isOut, pos) {
-        if (block>=input.length) return 0n;
+        if (block >= input.length) return 0n;
         const st = isOut ? input[block][1] : input[block][0]
-        return BigInt(bitFromState(st, pos ));
+        return BigInt(bitFromState(st, pos));
     }
 }
 
-function bitFromState(st, i) {
+function bitFromState(state, i) {
 
     const y = Math.floor(i / 320);
     const x = Math.floor((i % 320) / 64);
     const z = i % 64
     const z1 = Math.floor(z / 32);
-    const z2 = z%32;
+    const z2 = z % 32;
 
-    return BigInt((st[x][y][z1] >> z2) & 1);
+    return BigInt((state[x][y][z1] >> z2) & 1);
 
 }


### PR DESCRIPTION
SlotSize is changed to SLOT_SIZE to represent a constant
pols.FieldLatch.length is changed to fieldLatchLength to represent the length of the locked field
n is changed to fieldLatchLength to represent the length of the locked field
nSlots is changed to numSlots to represent the number of locked fields
iRel is changed to relativeIndex to represent the index relative to the locked field position
keccakFSlot is changed to keccakFSlot to represent the array of KeccakF slots
j is changed to rowIndex to represent the row index of the state
k is changed to bitIndex to represent the bit index of the state
accField is changed to accumulatedField to represent the accumulated field value
p is changed to bitIndex to represent the index of the bit
st is changed to state to represent the state array
z is changed to bitOffset to represent the offset of the state bit
z1 is changed to wordIndex to represent the index of the state word
z2 is changed to bitIndex to represent the bit index within the state word