### PR TITLE
chore: making starky traits public.

### DIFF
--- a/starky/src/lib.rs
+++ b/starky/src/lib.rs
@@ -3,7 +3,7 @@ pub mod polsarray;
 mod polutils;
 pub mod stark_verifier_circom;
 pub mod stark_verifier_circom_bn128;
-mod traits;
+pub mod traits;
 pub mod types;
 
 mod compressor12;


### PR DESCRIPTION
Otherwise the user won't be able to write generic code that depends on the type of the merkle tree.

E.g., currently on main, this gives compilation error on user code:
```rs
fn do_something<M: starky::traits::MerkleTree>(setup: &mut StarkSetup<M>)  {
    // ...
}
```