### PR TITLE
fix: customize the global.l1

### DIFF
--- a/SM/README.md
+++ b/SM/README.md
@@ -3,7 +3,11 @@ State Machine zkVM prototype extracted from [zkevm-proverjs](https://github.com/
 
 # Example
 
-### Arithmetization
+### Generate TX batch
+
+[gen-txs.js](tools/gen-input-executor/README.md)
+
+### Generate zkvm input
 ```
 npm run buildrom
 npm run buildstoragerom

--- a/plonky/src/witness/witness_calculator.rs
+++ b/plonky/src/witness/witness_calculator.rs
@@ -285,6 +285,7 @@ impl WitnessCalculator {
     }
 }
 
+#[allow(dead_code)]
 pub fn value_to_bigint(v: Value) -> BigInt {
     match v {
         Value::String(inner) => BigInt::from_str(&inner).unwrap(),

--- a/starky/src/compressor12/compressor12_pil.rs
+++ b/starky/src/compressor12/compressor12_pil.rs
@@ -1,4 +1,4 @@
-pub fn render(nBits: usize, nPublics: usize) -> String {
+pub fn render(n_bits: usize, n_publics: usize) -> String {
     let mut res = String::from("");
     res.push_str(&format!(
         r#"
@@ -7,9 +7,9 @@ constant %N = 2**{};
 namespace Global(%N);
     pol constant L1;
 "#,
-        nBits
+        n_bits
     ));
-    for i in (12..nPublics).step_by(12) {
+    for i in (12..n_publics).step_by(12) {
         res.push_str(&format!(
             r#"
     pol constant L{};
@@ -27,7 +27,7 @@ namespace Compressor(%N);
             "#
     ));
 
-    for i in 0..nPublics {
+    for i in 0..n_publics {
         res.push_str(&format!(
             r#"
     public pub{} = a[{}]({});
@@ -38,7 +38,7 @@ namespace Compressor(%N);
         ));
     }
 
-    for i in 0..nPublics {
+    for i in 0..n_publics {
         res.push_str(&format!(
             r#"
     Global.L{} * (a[{}] - :pub{}) = 0;

--- a/starky/src/compressor12/compressor12_setup.rs
+++ b/starky/src/compressor12/compressor12_setup.rs
@@ -1,4 +1,5 @@
 #![allow(non_snake_case)]
+#![allow(dead_code)]
 use crate::compressor12::compressor12_pil;
 use crate::r1cs2plonk::{r1cs2plonk, PlonkAdd, PlonkGate};
 use plonky::circom_circuit::R1CS;

--- a/starky/src/compressor12/compressor12_setup.rs
+++ b/starky/src/compressor12/compressor12_setup.rs
@@ -1,14 +1,9 @@
 #![allow(non_snake_case)]
 use crate::compressor12::compressor12_pil;
-use crate::errors::{EigenError, Result};
-use crate::f3g::F3G;
-use crate::polsarray;
 use crate::r1cs2plonk::{r1cs2plonk, PlonkAdd, PlonkGate};
-use crate::types::PIL;
 use plonky::circom_circuit::R1CS;
 use plonky::field_gl::Fr as FGL;
 use plonky::field_gl::GL;
-use plonky::Field;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
@@ -95,8 +90,8 @@ struct CustomGateInfo {
 
 fn get_custom_gate_info(
     r1cs: &R1CS<GL>,
-    pa: &Vec<PlonkGate>,
-    pc: &Vec<PlonkAdd>,
+    _pa: &Vec<PlonkGate>,
+    _pc: &Vec<PlonkAdd>,
 ) -> CustomGateInfo {
     let mut cmul_id = 0;
     let mut cmds_id = 0;
@@ -127,7 +122,7 @@ fn get_custom_gate_info(
 
     let mut n_cmul = 0;
     let mut n_mds = 0;
-    for (i, c) in r1cs.custom_gates_uses.iter().enumerate() {
+    for (_i, c) in r1cs.custom_gates_uses.iter().enumerate() {
         if c.id == cmul_id {
             n_cmul += 1;
         } else if c.id == cmds_id {

--- a/starky/src/constant.rs
+++ b/starky/src/constant.rs
@@ -5,7 +5,6 @@ use crate::poseidon_bn128::{load_constants, Constants};
 use crate::poseidon_bn128_opt::load_constants as load_constants_opt;
 use ff::*;
 use plonky::field_gl::Fr as FGL;
-use plonky::Field;
 use std::collections::HashMap;
 
 lazy_static::lazy_static! {
@@ -56,6 +55,7 @@ lazy_static::lazy_static! {
 
 pub const MIN_OPS_PER_THREAD: usize = 1 << 12;
 pub const MAX_OPS_PER_THREAD: usize = 1 << 18;
+pub const GLOBAL_L1: &str = "Global.L1";
 
 pub fn get_max_workers() -> usize {
     num_cpus::get() - 1

--- a/starky/src/digest.rs
+++ b/starky/src/digest.rs
@@ -120,7 +120,7 @@ impl From<ElementDigest> for [FGL; DIGEST_SIZE] {
 pub mod tests {
     use crate::digest::ElementDigest;
     use crate::field_bn128::Fr;
-    use ff::{Field, PrimeField};
+    use ff::PrimeField;
     use plonky::field_gl::Fr as FGL;
     use rand::Rand;
 

--- a/starky/src/fft_p.rs
+++ b/starky/src/fft_p.rs
@@ -97,7 +97,7 @@ pub fn interpolate_prepare(buff: &mut Vec<F3G>, n_pols: usize, nbits: usize) {
         interpolate_prepare_block(&mut bb, n_pols, start, SHIFT.clone(), i, n);
     }
     */
-    let mut tmp_buff = &mut buff[0..(n * n_pols)];
+    let tmp_buff = &mut buff[0..(n * n_pols)];
     tmp_buff
         .par_chunks_mut(n_per_thread_f * n_pols)
         .enumerate()
@@ -160,9 +160,6 @@ pub fn _fft(
     }
     (bin, bout) = (bout, bin);
 
-    if n_pols <= 0 {
-        return;
-    }
     rayon::scope(|_s| {
         for i in (0..nbits).step_by(blockbits) {
             let s_inc = min(blockbits, nbits - i);

--- a/starky/src/fft_p.rs
+++ b/starky/src/fft_p.rs
@@ -160,6 +160,9 @@ pub fn _fft(
     }
     (bin, bout) = (bout, bin);
 
+    if n_pols <= 0 {
+        return;
+    }
     rayon::scope(|_s| {
         for i in (0..nbits).step_by(blockbits) {
             let s_inc = min(blockbits, nbits - i);

--- a/starky/src/merklehash.rs
+++ b/starky/src/merklehash.rs
@@ -283,7 +283,6 @@ mod tests {
     use crate::merklehash::MerkleTreeGL;
     use crate::traits::MerkleTree;
     use plonky::field_gl::Fr as FGL;
-    use plonky::Field;
 
     #[test]
     fn test_merklehash_gl_simple() {

--- a/starky/src/r1cs2plonk.rs
+++ b/starky/src/r1cs2plonk.rs
@@ -254,6 +254,6 @@ pub mod tests {
         let (pc, pa) = r1cs2plonk(&r1cs);
         println!("pc {}, pa {}", pc.len(), pa.len());
         let opts = Options { force_bits: 0 };
-        let plonksetupinfo = plonk_setup_render(&r1cs, &opts, "/tmp/c12.pil");
+        let _plonksetupinfo = plonk_setup_render(&r1cs, &opts, "/tmp/c12.pil");
     }
 }

--- a/starky/src/stark_gen.rs
+++ b/starky/src/stark_gen.rs
@@ -1061,7 +1061,7 @@ pub mod tests {
 
         let stark_struct = load_json::<StarkStruct>("data/starkStruct.json").unwrap();
         let mut setup =
-            StarkSetup::<MerkleTreeBN128>::new(&const_pol, &mut pil, &stark_struct).unwrap();
+            StarkSetup::<MerkleTreeBN128>::new(&const_pol, &mut pil, &stark_struct, None).unwrap();
         let fr_root: Fr = setup.const_root.into();
         log::info!("setup {}", fr_root);
         let starkproof = StarkProof::<MerkleTreeBN128>::stark_gen::<TranscriptBN128>(
@@ -1099,7 +1099,7 @@ pub mod tests {
 
         let stark_struct = load_json::<StarkStruct>("data/starkStruct.json").unwrap();
         let mut setup =
-            StarkSetup::<MerkleTreeBN128>::new(&const_pol, &mut pil, &stark_struct).unwrap();
+            StarkSetup::<MerkleTreeBN128>::new(&const_pol, &mut pil, &stark_struct, None).unwrap();
         let starkproof = StarkProof::<MerkleTreeBN128>::stark_gen::<TranscriptBN128>(
             &cm_pol,
             &const_pol,
@@ -1133,7 +1133,7 @@ pub mod tests {
         cm_pol.load("data/plookup.cm").unwrap();
         let stark_struct = load_json::<StarkStruct>("data/starkStruct.json").unwrap();
         let mut setup =
-            StarkSetup::<MerkleTreeBN128>::new(&const_pol, &mut pil, &stark_struct).unwrap();
+            StarkSetup::<MerkleTreeBN128>::new(&const_pol, &mut pil, &stark_struct, None).unwrap();
         let starkproof = StarkProof::<MerkleTreeBN128>::stark_gen::<TranscriptBN128>(
             &cm_pol,
             &const_pol,
@@ -1165,7 +1165,7 @@ pub mod tests {
         cm_pol.load("data/connection.cm").unwrap();
         let stark_struct = load_json::<StarkStruct>("data/starkStruct.json").unwrap();
         let mut setup =
-            StarkSetup::<MerkleTreeBN128>::new(&const_pol, &mut pil, &stark_struct).unwrap();
+            StarkSetup::<MerkleTreeBN128>::new(&const_pol, &mut pil, &stark_struct, None).unwrap();
         let starkproof = StarkProof::<MerkleTreeBN128>::stark_gen::<TranscriptBN128>(
             &cm_pol,
             &const_pol,
@@ -1197,7 +1197,7 @@ pub mod tests {
         cm_pol.load("data/plookup.cm.gl").unwrap();
         let stark_struct = load_json::<StarkStruct>("data/starkStruct.json.gl").unwrap();
         let mut setup =
-            StarkSetup::<MerkleTreeGL>::new(&const_pol, &mut pil, &stark_struct).unwrap();
+            StarkSetup::<MerkleTreeGL>::new(&const_pol, &mut pil, &stark_struct, None).unwrap();
         let starkproof = StarkProof::<MerkleTreeGL>::stark_gen::<TranscriptGL>(
             &cm_pol,
             &const_pol,

--- a/starky/src/stark_gen.rs
+++ b/starky/src/stark_gen.rs
@@ -1047,7 +1047,7 @@ pub mod tests {
     use crate::types::load_json;
     use crate::types::{StarkStruct, PIL};
 
-    use crate::field_bn128::{Fr, FrRepr};
+    use crate::field_bn128::Fr;
 
     #[test]
     fn test_stark_gen() {

--- a/starky/src/stark_setup.rs
+++ b/starky/src/stark_setup.rs
@@ -22,6 +22,7 @@ pub struct StarkSetup<M: MerkleTree> {
 ///
 ///  calculate the trace polynomial over extended field, return the new polynomial's coefficient.
 impl<M: MerkleTree> StarkSetup<M> {
+    //  https://github.com/0xEigenLabs/eigen-zkvm/pull/91
     pub fn new(
         const_pol: &PolsArray,
         pil: &mut PIL,

--- a/starky/src/stark_setup.rs
+++ b/starky/src/stark_setup.rs
@@ -26,6 +26,7 @@ impl<M: MerkleTree> StarkSetup<M> {
         const_pol: &PolsArray,
         pil: &mut PIL,
         stark_struct: &StarkStruct,
+        global_l1: Option<String>,
     ) -> Result<StarkSetup<M>> {
         let nBits = stark_struct.nBits;
         let nBitsExt = stark_struct.nBitsExt;
@@ -65,7 +66,7 @@ impl<M: MerkleTree> StarkSetup<M> {
             const_pol.n << (nBitsExt - nBits),
         )?;
 
-        let starkinfo = starkinfo::StarkInfo::new(pil, stark_struct, None)?;
+        let starkinfo = starkinfo::StarkInfo::new(pil, stark_struct, global_l1)?;
         Ok(StarkSetup {
             const_root: const_tree.root(),
             const_tree: const_tree,
@@ -96,7 +97,7 @@ pub mod tests {
 
         let stark_struct = load_json::<StarkStruct>("data/starkStruct.json").unwrap();
         let setup =
-            StarkSetup::<MerkleTreeBN128>::new(&const_pol, &mut pil, &stark_struct).unwrap();
+            StarkSetup::<MerkleTreeBN128>::new(&const_pol, &mut pil, &stark_struct, None).unwrap();
         let root: Fr = setup.const_root.into();
 
         let expect_root =
@@ -111,7 +112,8 @@ pub mod tests {
         const_pol.load("data/fib.const.gl").unwrap();
 
         let stark_struct = load_json::<StarkStruct>("data/starkStruct.json.gl").unwrap();
-        let setup = StarkSetup::<MerkleTreeGL>::new(&const_pol, &mut pil, &stark_struct).unwrap();
+        let setup =
+            StarkSetup::<MerkleTreeGL>::new(&const_pol, &mut pil, &stark_struct, None).unwrap();
 
         let expect_root = ElementDigest::from([
             FGL::from(15302509084042343527u64),

--- a/starky/src/stark_setup.rs
+++ b/starky/src/stark_setup.rs
@@ -65,7 +65,7 @@ impl<M: MerkleTree> StarkSetup<M> {
             const_pol.n << (nBitsExt - nBits),
         )?;
 
-        let starkinfo = starkinfo::StarkInfo::new(pil, stark_struct)?;
+        let starkinfo = starkinfo::StarkInfo::new(pil, stark_struct, None)?;
         Ok(StarkSetup {
             const_root: const_tree.root(),
             const_tree: const_tree,

--- a/starky/src/stark_setup.rs
+++ b/starky/src/stark_setup.rs
@@ -22,7 +22,7 @@ pub struct StarkSetup<M: MerkleTree> {
 ///
 ///  calculate the trace polynomial over extended field, return the new polynomial's coefficient.
 impl<M: MerkleTree> StarkSetup<M> {
-    //  https://github.com/0xEigenLabs/eigen-zkvm/pull/91
+    // global_l1: https://github.com/0xEigenLabs/eigen-zkvm/pull/91
     pub fn new(
         const_pol: &PolsArray,
         pil: &mut PIL,

--- a/starky/src/stark_verify.rs
+++ b/starky/src/stark_verify.rs
@@ -12,7 +12,6 @@ use crate::starkinfo_codegen::{Node, Section};
 use crate::traits::{MerkleTree, Transcript};
 use crate::types::StarkStruct;
 use plonky::field_gl::Fr as FGL;
-use plonky::Field;
 use std::collections::HashMap;
 
 //FIXME it doesn't make sense to ask for a mutable program

--- a/starky/src/starkinfo.rs
+++ b/starky/src/starkinfo.rs
@@ -248,7 +248,11 @@ impl fmt::Display for StarkInfo {
 }
 
 impl StarkInfo {
-    pub fn new(pil: &mut PIL, stark_struct: &StarkStruct) -> Result<(StarkInfo, Program)> {
+    pub fn new(
+        pil: &mut PIL,
+        stark_struct: &StarkStruct,
+        global_l1: Option<String>,
+    ) -> Result<(StarkInfo, Program)> {
         let pil_deg = pil.references.values().nth(0).unwrap().polDeg;
 
         let stark_deg = 2usize.pow(stark_struct.nBits as u32);
@@ -337,7 +341,7 @@ impl StarkInfo {
         info.generate_step2(&mut ctx, pil, &mut program)?; // H1, H2
 
         log::info!("generate_step3");
-        info.generate_step3(&mut ctx, pil, &mut program)?; // Z Polynonmial and LC of the permutation checks
+        info.generate_step3(&mut ctx, pil, &mut program, global_l1)?; // Z Polynonmial and LC of the permutation checks
 
         log::info!("generate_constraint_polynomial");
         info.generate_constraint_polynomial(

--- a/starky/src/starkinfo_Z.rs
+++ b/starky/src/starkinfo_Z.rs
@@ -115,11 +115,11 @@ impl StarkInfo {
             let z = E::cm(pu_ctx.z_id, None);
             let zp = E::cm(pu_ctx.z_id, Some(true));
 
-            if pil.references.get(&"Global.L1".to_string()).is_none() {
-                log::warn!("Global.L1 must be defined");
+            if pil.references.get(&"first_step".to_string()).is_none() {
+                panic!("first_step must be defined");
             }
 
-            let l1 = E::const_(pil.references[&"Global.L1".to_string()].id, None);
+            let l1 = E::const_(pil.references[&"first_step".to_string()].id, None);
             let mut c1 = E::mul(&l1, &E::sub(&z, &E::number("1".to_string())));
             c1.deg = 2;
 
@@ -207,10 +207,10 @@ impl StarkInfo {
             let z = E::cm(self.pe_ctx[i].z_id, None);
             let zp = E::cm(self.pe_ctx[i].z_id, Some(true));
 
-            if pil.references.get(&"Global.L1".to_string()).is_none() {
-                panic!("Global.L1 must be defined");
+            if pil.references.get(&"first_step".to_string()).is_none() {
+                panic!("first_step must be defined");
             }
-            let l1 = E::const_(pil.references[&"Global.L1".to_string()].id, None);
+            let l1 = E::const_(pil.references[&"first_step".to_string()].id, None);
             let mut c1 = E::mul(&l1, &E::sub(&z, &E::number("1".to_string())));
             c1.deg = 2;
 
@@ -364,10 +364,10 @@ impl StarkInfo {
             let z = E::cm(ci_ctx.z_id, None);
             let zp = E::cm(ci_ctx.z_id, Some(true));
 
-            if pil.references.get(&"Global.L1".to_string()).is_none() {
-                panic!("Global.L1 must be defined");
+            if pil.references.get(&"first_step".to_string()).is_none() {
+                panic!("first_step must be defined");
             }
-            let l1 = E::const_(pil.references[&"Global.L1".to_string()].id, None);
+            let l1 = E::const_(pil.references[&"first_step".to_string()].id, None);
             let mut c1 = E::mul(&l1, &E::sub(&z, &E::number("1".to_string())));
             c1.deg = 2;
 

--- a/starky/src/starkinfo_Z.rs
+++ b/starky/src/starkinfo_Z.rs
@@ -115,11 +115,11 @@ impl StarkInfo {
             let z = E::cm(pu_ctx.z_id, None);
             let zp = E::cm(pu_ctx.z_id, Some(true));
 
-            if pil.references.get(&"first_step".to_string()).is_none() {
-                panic!("first_step must be defined");
+            if pil.references.get(&"main.first_step".to_string()).is_none() {
+                panic!("main.first_step must be defined: {:?}", pil.references);
             }
 
-            let l1 = E::const_(pil.references[&"first_step".to_string()].id, None);
+            let l1 = E::const_(pil.references[&"main.first_step".to_string()].id, None);
             let mut c1 = E::mul(&l1, &E::sub(&z, &E::number("1".to_string())));
             c1.deg = 2;
 
@@ -207,10 +207,10 @@ impl StarkInfo {
             let z = E::cm(self.pe_ctx[i].z_id, None);
             let zp = E::cm(self.pe_ctx[i].z_id, Some(true));
 
-            if pil.references.get(&"first_step".to_string()).is_none() {
-                panic!("first_step must be defined");
+            if pil.references.get(&"main.first_step".to_string()).is_none() {
+                panic!("main.first_step must be defined");
             }
-            let l1 = E::const_(pil.references[&"first_step".to_string()].id, None);
+            let l1 = E::const_(pil.references[&"main.first_step".to_string()].id, None);
             let mut c1 = E::mul(&l1, &E::sub(&z, &E::number("1".to_string())));
             c1.deg = 2;
 
@@ -364,10 +364,10 @@ impl StarkInfo {
             let z = E::cm(ci_ctx.z_id, None);
             let zp = E::cm(ci_ctx.z_id, Some(true));
 
-            if pil.references.get(&"first_step".to_string()).is_none() {
-                panic!("first_step must be defined");
+            if pil.references.get(&"main.first_step".to_string()).is_none() {
+                panic!("main.first_step must be defined");
             }
-            let l1 = E::const_(pil.references[&"first_step".to_string()].id, None);
+            let l1 = E::const_(pil.references[&"main.first_step".to_string()].id, None);
             let mut c1 = E::mul(&l1, &E::sub(&z, &E::number("1".to_string())));
             c1.deg = 2;
 

--- a/starky/src/starkinfo_Z.rs
+++ b/starky/src/starkinfo_Z.rs
@@ -116,7 +116,7 @@ impl StarkInfo {
             let zp = E::cm(pu_ctx.z_id, Some(true));
 
             if pil.references.get(&"Global.L1".to_string()).is_none() {
-                log::warning!("Global.L1 must be defined");
+                log::warn!("Global.L1 must be defined");
             }
 
             let l1 = E::const_(pil.references[&"Global.L1".to_string()].id, None);

--- a/starky/src/starkinfo_Z.rs
+++ b/starky/src/starkinfo_Z.rs
@@ -116,7 +116,7 @@ impl StarkInfo {
             let zp = E::cm(pu_ctx.z_id, Some(true));
 
             if pil.references.get(&"Global.L1".to_string()).is_none() {
-                panic!("Global.L1 must be defined");
+                log::warning!("Global.L1 must be defined");
             }
 
             let l1 = E::const_(pil.references[&"Global.L1".to_string()].id, None);

--- a/zkit/src/stark.rs
+++ b/zkit/src/stark.rs
@@ -35,7 +35,8 @@ pub fn prove(
     match stark_struct.verificationHashType.as_str() {
         "BN128" => {
             let mut setup =
-                StarkSetup::<MerkleTreeBN128>::new(&const_pol, &mut pil, &stark_struct).unwrap();
+                StarkSetup::<MerkleTreeBN128>::new(&const_pol, &mut pil, &stark_struct, None)
+                    .unwrap();
             let mut starkproof = StarkProof::<MerkleTreeBN128>::stark_gen::<TranscriptBN128>(
                 &cm_pol,
                 &const_pol,
@@ -90,7 +91,7 @@ pub fn prove(
         }
         "GL" => {
             let mut setup =
-                StarkSetup::<MerkleTreeGL>::new(&const_pol, &mut pil, &stark_struct).unwrap();
+                StarkSetup::<MerkleTreeGL>::new(&const_pol, &mut pil, &stark_struct, None).unwrap();
             let mut starkproof = StarkProof::<MerkleTreeGL>::stark_gen::<TranscriptGL>(
                 &cm_pol,
                 &const_pol,


### PR DESCRIPTION
In the permutation argument, we need a constant constraint polynomial, namely Global.L1 to indicate the first step in the permutation check. However, some implements, like [powdr](https://github.com/powdr-labs/powdr/tree/stark-via-eigen), use the name `main.first_step` as the polynomial. So in this PR, we use a variable to represent the name as the argument of StarkSetup::new.