### PR TITLE
Ommiting Reference::polType field in serialization if not avaliable.

### DIFF
--- a/starky/src/types.rs
+++ b/starky/src/types.rs
@@ -18,6 +18,7 @@ pub struct Public {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Reference {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub polType: Option<String>,
     #[serde(rename = "type")]
     pub type_: String,

--- a/starky/src/types.rs
+++ b/starky/src/types.rs
@@ -108,9 +108,7 @@ pub struct PlookupIdentity {
     pub f: Option<Vec<usize>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub t: Option<Vec<usize>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub selF: Option<usize>, //selector
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub selT: Option<usize>,
     pub fileName: String,
     pub line: usize,
@@ -122,9 +120,7 @@ pub struct PermutationIdentity {
     pub f: Option<Vec<usize>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub t: Option<Vec<usize>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub selF: Option<usize>, //selector
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub selT: Option<usize>,
     pub fileName: String,
     pub line: usize,


### PR DESCRIPTION
This mimics better pilcom behavior.