### PR TITLE
chore: upgrade ff

### DIFF
--- a/recursion/Cargo.toml
+++ b/recursion/Cargo.toml
@@ -27,7 +27,7 @@ num = { version = "0.4.0" }
 byteorder = "1"
 franklin-crypto = { git = "https://github.com/matter-labs/franklin-crypto", branch = "beta", features = [ "plonk" ], version = "0.0.5"}
 #franklin-crypto = { path = "../../franklin-crypto", features = [ "plonk" ], version = "0.0.5"}
-ff = {package="ff_ce" , version="0.11", features = ["derive"]}
+ff = {package="ff_ce" , version="0.12", features = ["derive"]}
 fields = { path = "../fields", default-features = false }
 starky = { path = "../starky", default-features = false }
 plonky = { path = "../plonky", default-features = false }

--- a/starky/Cargo.toml
+++ b/starky/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = "1.0"
 byteorder = "1"
 
 # hash
-ff = {package="ff_ce" , version="0.11", features = ["derive"]}
+ff = {package="ff_ce" , version="0.12", features = ["derive"]}
 rand = "0.4"
 lazy_static = "1.0"
 


### PR DESCRIPTION
If we upgrade it to 0.12 here, then:

- 0.12 is in sync with other halo2 related packages
- in powdr, we can point starky's version to the latest, increasing powdr's min version of `ff_ce` to 0.11. Currently both 0.11 and 0.12 are used.
- after that we can point the powdr version to the latest here, so that everyone is synced on 0.12