### PR TITLE
chore: use avx512 x86 feature only behind a crate avx512 feature

### DIFF
--- a/fields/src/lib.rs
+++ b/fields/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(stdarch_x86_avx512)]
+#![cfg_attr(feature = "avx512", feature(stdarch_x86_avx512))]
 //#![cfg_attr(feature = "avx512", feature(stdsimd))]
 extern crate rand;
 

--- a/starky/src/lib.rs
+++ b/starky/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(dead_code)]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::too_many_arguments)]
-#![feature(stdarch_x86_avx512)]
+#![cfg_attr(feature = "avx512", feature(stdarch_x86_avx512))]
 
 pub mod polsarray;
 pub mod polutils;


### PR DESCRIPTION
- [x] #230 