### PR TITLE
feat: groth16 return object in-memory

### DIFF
--- a/groth16/src/api.rs
+++ b/groth16/src/api.rs
@@ -208,7 +208,7 @@ pub fn groth16_prove(
 
 #[cfg(not(any(feature = "cuda", feature = "opencl")))]
 #[allow(clippy::too_many_arguments)]
-pub fn groth16_prove_with_cache<E: Engine + crate::json_utils::Parser>(
+pub fn groth16_prove_inplace<E: Engine + crate::json_utils::Parser>(
     curve_type: &str,
     circuit: CircomCircuit<E>,
     wtns_file: &str,
@@ -279,7 +279,7 @@ pub fn groth16_prove(
 
 #[cfg(any(feature = "cuda", feature = "opencl"))]
 #[allow(clippy::too_many_arguments)]
-pub fn groth16_prove_with_cache(
+pub fn groth16_prove_inplace(
     curve_type: &str,
     circuit: CircomCircuit<Scalar>,
     wtns_file: &str,

--- a/groth16/src/api.rs
+++ b/groth16/src/api.rs
@@ -567,9 +567,19 @@ fn create_circuit_from_file<E: PrimeField>(
 #[cfg(any(feature = "cuda", feature = "opencl"))]
 fn create_circuit_add_witness<E: PrimeField>(
     mut circuit: CircomCircuit<E>,
-    witness: Option<Vec<E>>,
+    witness: Vec<num_bigint::BigInt>,
 ) -> CircomCircuit<E> {
-    circuit.witness = witness;
+    let w = witness
+        .iter()
+        .map(|wi| {
+            if wi.is_zero() {
+                Scalar::ZERO
+            } else {
+                Scalar::from_str_vartime(&wi.to_string()).unwrap()
+            }
+        })
+        .collect::<Vec<_>>();
+    circuit.witness = w;
     circuit
 }
 

--- a/groth16/src/api.rs
+++ b/groth16/src/api.rs
@@ -73,25 +73,17 @@ pub enum SetupResult {
 }
 
 #[cfg(not(any(feature = "cuda", feature = "opencl")))]
-pub fn groth16_setup_and_cache(
-    curve_type: &str,
-    circuit_file: &str,
-    pk_file: &str,
-    vk_file: &str,
-    to_hex: bool,
-) -> Result<SetupResult> {
+pub fn groth16_setup_inplace(curve_type: &str, circuit_file: &str) -> Result<SetupResult> {
     let mut rng = rand::thread_rng();
     let result = match curve_type {
         "BN128" => {
             let circuit = create_circuit_from_file::<Bn256>(circuit_file, None);
             let (pk, vk) = Groth16::circuit_specific_setup(circuit.clone(), &mut rng)?;
-            write_pk_vk_to_files(curve_type, pk.clone(), vk.clone(), pk_file, vk_file, to_hex)?;
             SetupResult::BN128(circuit, pk, vk)
         }
         "BLS12381" => {
             let circuit = create_circuit_from_file::<Bls12>(circuit_file, None);
             let (pk, vk) = Groth16::circuit_specific_setup(circuit.clone(), &mut rng)?;
-            write_pk_vk_to_files(curve_type, pk.clone(), vk.clone(), pk_file, vk_file, to_hex)?;
             SetupResult::BLS12381(circuit, pk, vk)
         }
         _ => {
@@ -135,20 +127,13 @@ pub enum SetupResult {
 }
 
 #[cfg(any(feature = "cuda", feature = "opencl"))]
-pub fn groth16_setup_and_cache(
-    curve_type: &str,
-    circuit_file: &str,
-    pk_file: &str,
-    vk_file: &str,
-    to_hex: bool,
-) -> Result<SetupResult> {
+pub fn groth16_setup_inplace(curve_type: &str, circuit_file: &str) -> Result<SetupResult> {
     let mut rng = rand::thread_rng();
     let result = match curve_type {
         "BLS12381" => {
             let circuit = create_circuit_from_file::<Scalar>(circuit_file, None);
             let (pk, vk): (Parameters<Bls12>, VerifyingKey<Bls12>) =
                 Groth16::circuit_specific_setup(circuit.clone(), &mut rng)?;
-            write_pk_vk_to_files(curve_type, pk.clone(), vk.clone(), pk_file, vk_file, to_hex)?;
             SetupResult::BLS12381(circuit, pk, vk)
         }
         _ => {

--- a/groth16/src/groth16.rs
+++ b/groth16/src/groth16.rs
@@ -114,8 +114,10 @@ mod tests {
     use num_traits::Zero;
 
     use super::*;
+    use crate::api::create_circuit_add_witness;
+    use crate::api::groth16_setup_and_cache;
+    use crate::api::SetupResult;
     use crate::bellman_ce::bls12_381::Bls12;
-    use crate::bellman_ce::bls12_381::Fr as Fr_bls12381;
     use crate::bellman_ce::bn256::{Bn256, Fr};
     use algebraic::circom_circuit::CircomCircuit;
     use algebraic::reader;
@@ -130,6 +132,11 @@ mod tests {
     const WASM_FILE_BLS12: &str = concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/test-vectors/mycircuit_bls12381.wasm"
+    );
+    const ZKEY: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/test-vectors/g16.zkey");
+    const VKEY: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/test-vectors/verification_key.json"
     );
 
     #[test]
@@ -188,53 +195,34 @@ mod tests {
     }
 
     #[test]
-    fn groth16_proof_bls12381() -> Result<()> {
+    fn groth16_proof_bls12381_with_cache() -> Result<()> {
         //1. SRS
         let t = std::time::Instant::now();
-        let circuit: CircomCircuit<Bls12> = CircomCircuit {
-            r1cs: reader::load_r1cs(CIRCUIT_FILE_BLS12),
-            witness: None,
-            wire_mapping: None,
-            aux_offset: 0,
+        let setup_result =
+            groth16_setup_and_cache("BLS12381", CIRCUIT_FILE_BLS12, ZKEY, VKEY, true)?;
+        let (circuit, pk, vk) = match setup_result {
+            SetupResult::BLS12381(circuit, pk, vk) => (circuit, pk, vk),
+            _ => panic!("Expected BLS12381 setup result"),
         };
-        let mut rng = rand::thread_rng();
-        let params = Groth16::circuit_specific_setup(circuit, &mut rng)?;
         let elapsed = t.elapsed().as_secs_f64();
         println!("1-groth16-bls12381 setup run time: {} secs", elapsed);
 
         //2. Prove
         let t1 = std::time::Instant::now();
-        // let mut wtns = WitnessCalculator::new(WASM_FILE_BLS12).unwrap();
+        let mut rng = rand::thread_rng();
         let mut wtns = WitnessCalculator::from_file(WASM_FILE_BLS12)?;
         let inputs = load_input_for_witness(INPUT_FILE);
         let w = wtns.calculate_witness(inputs, false).unwrap();
-        let w = w
-            .iter()
-            .map(|wi| {
-                if wi.is_zero() {
-                    Fr_bls12381::zero()
-                } else {
-                    // println!("wi: {}", wi);
-                    Fr_bls12381::from_str(&wi.to_string()).unwrap()
-                }
-            })
-            .collect::<Vec<_>>();
-        let circuit1: CircomCircuit<Bls12> = CircomCircuit {
-            r1cs: reader::load_r1cs(CIRCUIT_FILE_BLS12),
-            witness: Some(w),
-            wire_mapping: None,
-            aux_offset: 0,
-        };
-        let inputs = circuit1.get_public_inputs().unwrap();
-        let proof = Groth16::prove(&params.0, circuit1, &mut rng)?;
+        let circuit1: CircomCircuit<Bls12> = create_circuit_add_witness::<Bls12>(circuit, w);
+        let proof = Groth16::prove(&pk, circuit1.clone(), &mut rng)?;
         let elapsed1 = t1.elapsed().as_secs_f64();
         println!("2-groth16-bls12381 prove run time: {} secs", elapsed1);
 
         //3. Verify
         let t2 = std::time::Instant::now();
-        let verified = Groth16::<_, CircomCircuit<Bls12>>::verify_with_processed_vk(
-            &params.1, &inputs, &proof,
-        )?;
+        let inputs = circuit1.get_public_inputs().unwrap();
+        let verified =
+            Groth16::<_, CircomCircuit<Bls12>>::verify_with_processed_vk(&vk, &inputs, &proof)?;
         let elapsed2 = t2.elapsed().as_secs_f64();
         println!("3-groth16-bls12381 verify run time: {} secs", elapsed2);
 
@@ -248,11 +236,13 @@ mod tests {
 #[cfg(any(feature = "cuda", feature = "opencl"))]
 mod tests {
     use super::*;
+    use crate::api::{create_circuit_add_witness, groth16_setup_and_cache, SetupResult};
     use algebraic::witness::{load_input_for_witness, WitnessCalculator};
     use algebraic_gpu::circom_circuit::CircomCircuit;
     use algebraic_gpu::reader;
     use blstrs::{Bls12, Scalar};
     use ff::{Field, PrimeField};
+    use log::info;
     use num_traits::Zero;
     use rand_new::rngs::OsRng;
     const INPUT_FILE: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../test/multiplier.input.json");
@@ -264,56 +254,43 @@ mod tests {
         env!("CARGO_MANIFEST_DIR"),
         "/test-vectors/mycircuit_bls12381.wasm"
     );
+    const ZKEY: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/test-vectors/g16.zkey");
+    const VKEY: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/test-vectors/verification_key.json"
+    );
 
     #[test]
-    fn groth16_proof() -> Result<()> {
+    fn groth16_proof_bls12381_with_cache() -> Result<()> {
+        let _ = env_logger::try_init();
         //1. SRS
         let t = std::time::Instant::now();
-        let circuit: CircomCircuit<Scalar> = CircomCircuit {
-            r1cs: reader::load_r1cs(CIRCUIT_FILE_BLS12),
-            witness: None,
-            wire_mapping: None,
-            aux_offset: 0,
+        let setup_result =
+            groth16_setup_and_cache("BLS12381", CIRCUIT_FILE_BLS12, ZKEY, VKEY, true)?;
+        let (circuit, pk, vk) = match setup_result {
+            SetupResult::BLS12381(circuit, pk, vk) => (circuit, pk, vk),
+            _ => panic!("Expected BLS12381 setup result"),
         };
-        let params = Groth16::circuit_specific_setup(circuit, &mut OsRng)?;
         let elapsed = t.elapsed().as_secs_f64();
-        println!("1-groth16-bls12381 setup run time: {} secs", elapsed);
+        info!("1-groth16-bls12381 setup run time: {} secs", elapsed);
 
         //2. Prove
         let t1 = std::time::Instant::now();
         let mut wtns = WitnessCalculator::from_file(WASM_FILE_BLS12)?;
         let inputs = load_input_for_witness(INPUT_FILE);
         let w = wtns.calculate_witness(inputs, false).unwrap();
-        let w = w
-            .iter()
-            .map(|wi| {
-                if wi.is_zero() {
-                    <Bls12 as Engine>::Fr::ZERO
-                } else {
-                    // println!("wi: {}", wi);
-                    <Bls12 as Engine>::Fr::from_str_vartime(&wi.to_string()).unwrap()
-                }
-            })
-            .collect::<Vec<_>>();
-        let circuit1: CircomCircuit<Scalar> = CircomCircuit {
-            r1cs: reader::load_r1cs(CIRCUIT_FILE_BLS12),
-            witness: Some(w),
-            wire_mapping: None,
-            aux_offset: 0,
-        };
-        let inputs = circuit1.get_public_inputs().unwrap();
-        let proof: bellperson::groth16::Proof<Bls12> =
-            Groth16::prove(&params.0, circuit1, &mut OsRng)?;
+        let circuit1: CircomCircuit<Scalar> = create_circuit_add_witness(circuit, w);
+        let proof = Groth16::prove(&pk, circuit1.clone(), &mut OsRng)?;
         let elapsed1 = t1.elapsed().as_secs_f64();
-        println!("2-groth16-bls12381 prove run time: {} secs", elapsed1);
+        info!("2-groth16-bls12381 prove run time: {} secs", elapsed1);
 
         //3. Verify
         let t2 = std::time::Instant::now();
-        let verified = Groth16::<_, CircomCircuit<Scalar>>::verify_with_processed_vk(
-            &params.1, &inputs, &proof,
-        )?;
+        let inputs = circuit1.get_public_inputs().unwrap();
+        let verified =
+            Groth16::<_, CircomCircuit<Scalar>>::verify_with_processed_vk(&vk, &inputs, &proof)?;
         let elapsed2 = t2.elapsed().as_secs_f64();
-        println!("3-groth16-bls12381 verify run time: {} secs", elapsed2);
+        info!("3-groth16-bls12381 verify run time: {} secs", elapsed2);
 
         assert!(verified);
 

--- a/groth16/src/groth16.rs
+++ b/groth16/src/groth16.rs
@@ -190,7 +190,7 @@ mod tests {
     }
 
     #[test]
-    fn groth16_proof_bls12381_with_cache() -> Result<()> {
+    fn groth16_proof_bls12381_inpace() -> Result<()> {
         //1. SRS
         let t = std::time::Instant::now();
         let setup_result = groth16_setup_inplace("BLS12381", CIRCUIT_FILE_BLS12)?;
@@ -250,7 +250,7 @@ mod tests {
     );
 
     #[test]
-    fn groth16_proof_bls12381_with_cache() -> Result<()> {
+    fn groth16_proof_bls12381_inplace() -> Result<()> {
         let _ = env_logger::try_init();
         //1. SRS
         let t = std::time::Instant::now();

--- a/groth16/src/groth16.rs
+++ b/groth16/src/groth16.rs
@@ -115,7 +115,7 @@ mod tests {
 
     use super::*;
     use crate::api::create_circuit_add_witness;
-    use crate::api::groth16_setup_and_cache;
+    use crate::api::groth16_setup_inplace;
     use crate::api::SetupResult;
     use crate::bellman_ce::bls12_381::Bls12;
     use crate::bellman_ce::bn256::{Bn256, Fr};
@@ -132,11 +132,6 @@ mod tests {
     const WASM_FILE_BLS12: &str = concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/test-vectors/mycircuit_bls12381.wasm"
-    );
-    const ZKEY: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/test-vectors/g16.zkey");
-    const VKEY: &str = concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/test-vectors/verification_key.json"
     );
 
     #[test]
@@ -198,8 +193,7 @@ mod tests {
     fn groth16_proof_bls12381_with_cache() -> Result<()> {
         //1. SRS
         let t = std::time::Instant::now();
-        let setup_result =
-            groth16_setup_and_cache("BLS12381", CIRCUIT_FILE_BLS12, ZKEY, VKEY, true)?;
+        let setup_result = groth16_setup_inplace("BLS12381", CIRCUIT_FILE_BLS12)?;
         let (circuit, pk, vk) = match setup_result {
             SetupResult::BLS12381(circuit, pk, vk) => (circuit, pk, vk),
             _ => panic!("Expected BLS12381 setup result"),
@@ -236,7 +230,7 @@ mod tests {
 #[cfg(any(feature = "cuda", feature = "opencl"))]
 mod tests {
     use super::*;
-    use crate::api::{create_circuit_add_witness, groth16_setup_and_cache, SetupResult};
+    use crate::api::{create_circuit_add_witness, groth16_setup_inplace, SetupResult};
     use algebraic::witness::{load_input_for_witness, WitnessCalculator};
     use algebraic_gpu::circom_circuit::CircomCircuit;
     use algebraic_gpu::reader;
@@ -254,19 +248,13 @@ mod tests {
         env!("CARGO_MANIFEST_DIR"),
         "/test-vectors/mycircuit_bls12381.wasm"
     );
-    const ZKEY: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/test-vectors/g16.zkey");
-    const VKEY: &str = concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/test-vectors/verification_key.json"
-    );
 
     #[test]
     fn groth16_proof_bls12381_with_cache() -> Result<()> {
         let _ = env_logger::try_init();
         //1. SRS
         let t = std::time::Instant::now();
-        let setup_result =
-            groth16_setup_and_cache("BLS12381", CIRCUIT_FILE_BLS12, ZKEY, VKEY, true)?;
+        let setup_result = groth16_setup_inplace("BLS12381", CIRCUIT_FILE_BLS12)?;
         let (circuit, pk, vk) = match setup_result {
             SetupResult::BLS12381(circuit, pk, vk) => (circuit, pk, vk),
             _ => panic!("Expected BLS12381 setup result"),


### PR DESCRIPTION
fix ##267

| Task | CPU | CPU with Cache | GPU | GPU with Cache |
|:---|---:|---:|---:|---:|
| **t1**: Initialize the WitnessCalculator from the specified WASM_FILE | 0.1 | 0.1 | 0.1 | 0.1 |
| **t2**: Load inputs from INPUT_FILE, and calculate the witness | 43.4 | 40.5 | 43.1 | 40.8 |
| **t3**: Read the proving key (pk) from the specified ZKEY_FILE | 6.4 | - | 13.1 | - |
| **t4**: Create a CircomCircuit from the CIRCUIT_FILE using the calculated witness values | 50.1 | 2.7 | 50.0 | 4.0 |
| **t5**: Generate a Groth16 proof using the proving key (pk) and the created circuit (CircomCircuit) | 33.6 | 37.6 | 14.7 | 14.1 |
| **Total Time** | **133.6** | **80.9** | **121.0** | **59.0** |