### PR TITLE
fix: correct broken file path in zkit README.md

### DIFF
--- a/zkit/README.md
+++ b/zkit/README.md
@@ -1,6 +1,6 @@
 # eigen zkit
 
-A universal commandline for [plonky](../plonky) and [starky](../starky).
+A universal commandline for [recursion](../recursion) and [starky](../starky).
 
 ## Usage
 


### PR DESCRIPTION
Replace broken '../plonky' link with '../recursion' since plonky directory doesn't exist