### PR TITLE
fix(typos): correct spelling mistakes across JS and Rust sources

### DIFF
--- a/starkjs/src/utils.js
+++ b/starkjs/src/utils.js
@@ -5,7 +5,7 @@ module.exports = {
   // * Maximum degree of constraints d
   // * Domain blowup factor b
   // * Collision resistance of the hash function c
-  // * Nummber of queries n
+  // * Number of queries n
   // Security Level(bits):
   //   min(log2(q/(t*b)), log2(b/d)*n, c)
   security_test(starkStruct, execution_trace) {

--- a/starky/src/f5g.rs
+++ b/starky/src/f5g.rs
@@ -620,7 +620,7 @@ impl F5G {
         // order p^5-1), obtain that x^r is a root of the polynomial
         // X^(p-1) - 1. However, all non-zero elements of GF(p) are
         // roots of X^(p-1) - 1, and there are p-1 non-zero elements in
-        // GF(p), and a polynomial of degre p-1 cannot have more than
+        // GF(p), and a polynomial of degree p-1 cannot have more than
         // p-1 roots in a field. Therefore, the roots of X^(p-1) - 1
         // are _exactly_ the elements of GF(p). It follows that x^r is
         // in GF(p), for any x != 0 in GF(p^5) (this also holds for x = 0).

--- a/starky/src/fft_worker.rs
+++ b/starky/src/fft_worker.rs
@@ -10,9 +10,9 @@ pub fn interpolate_prepare_block<F: FieldExtension>(
     st_n: usize,
 ) {
     log::trace!("linear interpolatePrepare start....{}/{}", st_i, st_n);
-    let heigth = buff.len() / width;
+    let height = buff.len() / width;
     let mut w = start;
-    for i in 0..heigth {
+    for i in 0..height {
         for j in 0..width {
             buff[i * width + j] *= w;
         }
@@ -51,9 +51,9 @@ fn _fft_block<F: FieldExtension>(
     let mut w = F::ZERO;
     if s > blockbits {
         let width = 1 << (s - layers);
-        let heigth = n / width;
-        let y = start_pos / heigth;
-        let x = start_pos % heigth;
+        let height = n / width;
+        let y = start_pos / height;
+        let x = start_pos % height;
         let p = x * width + y;
         w = F::from(MG.0[s].exp(p as u64));
     } else {


### PR DESCRIPTION
In starkjs/src/utils.js:

- Replaced Nummber of queries with Number of queries

In starky/src/f5g.rs:

- Replaced degre with degree

In starky/src/fft_worker.rs:

- Replaced all instances of heigth with correct spelling height (including variable names and comments)