### PR TITLE
fix: correct typos in interpreter.rs and pil2circom.rs

### DIFF
--- a/starky/src/interpreter.rs
+++ b/starky/src/interpreter.rs
@@ -298,7 +298,7 @@ fn set_ref<T: FieldExtension>(
         "tmp" => Expr::new(Ops::Refer, vec!["tmp".to_string()], vec![], vec![r.id, 0, modulas, 0]),
         "q" => {
             if dom == "n" {
-                panic!("Accesssing q in domain n");
+                panic!("Accessing q in domain n");
             } else if dom == "2ns" {
                 if starkinfo.q_dim == 3 {
                     Expr::new(
@@ -323,7 +323,7 @@ fn set_ref<T: FieldExtension>(
         }
         "f" => {
             if dom == "n" {
-                panic!("Accesssing q in domain n");
+                panic!("Accessing q in domain n");
             } else if dom == "2ns" {
                 Expr::new(
                     Ops::Refer,

--- a/starky/src/pil2circom.rs
+++ b/starky/src/pil2circom.rs
@@ -11,7 +11,7 @@ pub struct StarkOption {
     pub enable_input: bool,
     // normalize the proof
     pub verkey_input: bool,
-    // aggragte the proof
+    // aggregate the proof
     pub agg_stage: bool,
     // generate the main component in Circom
     pub skip_main: bool,


### PR DESCRIPTION
Fixed repeated typo "Accesssing" → "Accessing" in starky/src/interpreter.rs.

Corrected spelling of "aggregate" in a comment in starky/src/pil2circom.rs.